### PR TITLE
fix: change how triggers are sent

### DIFF
--- a/packages/input-manager/src/devices/device.ts
+++ b/packages/input-manager/src/devices/device.ts
@@ -2,20 +2,25 @@ import EventEmitter from 'eventemitter3'
 import { StatusCode } from '@sofie-automation/shared-lib/dist/lib/status'
 import { SomeFeedback } from '../feedback/feedback'
 import { Logger } from '../logger'
+import { shiftMapFirstEntry } from '../lib'
 
 /**
- * Description of a the "trigger got triggered" event
- *
- * @interface TriggerEventArgs
+ * Description of a "trigger got triggered" event
  */
-export interface TriggerEventArgs {
-	/** ID of the triggered trigger, needs to individually identify a single source of events: an individual button, key, input, etc. */
+export interface TriggerEvent {
+	/**
+	 * ID of the trigger, individually identifies the source of the trigger:
+	 * ie: "key X pressed down", "key X pressed up", "knob Y rotated", "slider Z moved" etc..
+	 */
 	triggerId: string
-	/** A set of custom values describind the data received with the input event itself: pressure, voltage, value, etc. */
-	arguments?: Record<string, string | number | boolean>
-	/** Should this event replace whatever unsent events there are */
-	replacesPrevious?: boolean
+	/**
+	 * A set of custom values describing the data received with the input event itself:
+	 * pressure, voltage, value, etc.
+	 */
+	arguments?: TriggerEventArguments
 }
+
+export type TriggerEventArguments = Record<string, string | number | boolean>
 
 export interface ErrorArgs {
 	error: Error
@@ -26,13 +31,26 @@ export interface StatusChangeEventArgs {
 }
 
 type DeviceEvents = {
-	trigger: [e: TriggerEventArgs]
+	/** A notification that a trigger was triggered, call this.getNextTrigger() to get it when it's time to send it to Core. */
+	trigger: []
 	statusChange: [e: StatusChangeEventArgs]
 	error: [e: ErrorArgs]
 }
 
 export abstract class Device extends EventEmitter<DeviceEvents> {
 	protected logger: Logger
+
+	/** A list of triggered keys, in the order that they where triggered */
+	protected triggerKeys: {
+		triggerId: string
+		arguments?: any
+	}[] = []
+	/**
+	 * A map of trigger-analog values.
+	 * Keys are triggerIds
+	 * Values are the trigger Arguments
+	 */
+	protected triggerAnalogs = new Map<string, TriggerEventArguments>()
 
 	constructor(logger: Logger) {
 		super()
@@ -45,5 +63,22 @@ export abstract class Device extends EventEmitter<DeviceEvents> {
 	abstract init(): Promise<void>
 	async destroy(): Promise<void> {
 		this.removeAllListeners()
+	}
+
+	/**
+	 * Returns the next trigger to send to Core.
+	 * If there are no more triggers to send, return undefined
+	 */
+	getNextTrigger(): TriggerEvent | undefined {
+		{
+			const e = this.triggerKeys.shift()
+			if (e) return { triggerId: e.triggerId, arguments: e.arguments }
+		}
+		{
+			const e = shiftMapFirstEntry(this.triggerAnalogs)
+			if (e) return { triggerId: e.key, arguments: e.value }
+		}
+
+		return undefined
 	}
 }

--- a/packages/input-manager/src/index.ts
+++ b/packages/input-manager/src/index.ts
@@ -1,6 +1,13 @@
-import { InputManager, SomeDeviceConfig, TriggerEventArgs, getIntegrationsConfigManifest } from './inputManager'
+import {
+	InputManager,
+	SomeDeviceConfig,
+	TriggerEventArgs,
+	getIntegrationsConfigManifest,
+	ManagerTriggerEventArgs,
+} from './inputManager'
 import { Feedback, SomeFeedback, ClassNames, Tally } from './feedback/feedback'
 import { DeviceType } from './integrations/deviceType'
+import { TriggerEvent } from './devices/device'
 
 export {
 	InputManager,
@@ -12,4 +19,6 @@ export {
 	ClassNames,
 	Tally,
 	getIntegrationsConfigManifest,
+	ManagerTriggerEventArgs,
+	TriggerEvent,
 }

--- a/packages/input-manager/src/integrations/http/__tests__/http.spec.ts
+++ b/packages/input-manager/src/integrations/http/__tests__/http.spec.ts
@@ -44,11 +44,18 @@ describe('HTTP Server', () => {
 
 		const method = 'POST'
 		const url = '/mock/0'
+		const headers = {
+			'accept-encoding': 'gzip, deflate, br',
+			accept: '*/*',
+			'user-agent': 'Unit test',
+			host: 'localhost:8000',
+		}
 
 		mockRequestClb(
 			{
 				method,
 				url,
+				headers,
 			},
 			{
 				end: responseEnd,

--- a/packages/input-manager/src/integrations/http/__tests__/http.spec.ts
+++ b/packages/input-manager/src/integrations/http/__tests__/http.spec.ts
@@ -56,9 +56,11 @@ describe('HTTP Server', () => {
 		)
 
 		expect(triggerHandler).toHaveBeenCalledTimes(1)
-		expect(triggerHandler.mock.calls[0][0]).toMatchObject({
+		expect(device.getNextTrigger()).toMatchObject({
 			triggerId: `${method} ${url}`,
 		})
+		expect(device.getNextTrigger()).toBeUndefined() // No more triggers to send
+
 		expect(responseEnd).toHaveBeenCalledTimes(1)
 	})
 })

--- a/packages/input-manager/src/integrations/http/index.ts
+++ b/packages/input-manager/src/integrations/http/index.ts
@@ -28,9 +28,10 @@ export class HTTPDevice extends Device {
 	async init(): Promise<void> {
 		this.#server = new Server((req, res) => {
 			const triggerId = `${req.method ?? 'GET'} ${req.url}`
-			this.emit('trigger', {
-				triggerId,
-			})
+
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
+
 			res.end()
 		})
 		this.#server.listen(this.#config.port)

--- a/packages/input-manager/src/integrations/http/index.ts
+++ b/packages/input-manager/src/integrations/http/index.ts
@@ -31,7 +31,7 @@ export class HTTPDevice extends Device {
 				// Example: "https://localhost:8000/my/trigger/path?param0=hey#myHash"
 
 				const triggerArguments: TriggerEventArguments = {}
-				const url = new URL(req.url, 'http://localhost')
+				const url = new URL(req.url, `http://${req.headers.host}`)
 				const searchParams: Record<string, any> = {}
 				for (const [key, value] of url.searchParams.entries()) {
 					searchParams[key] = value

--- a/packages/input-manager/src/integrations/http/index.ts
+++ b/packages/input-manager/src/integrations/http/index.ts
@@ -43,8 +43,7 @@ export class HTTPDevice extends Device {
 
 				const triggerId = `${req.method ?? 'GET'} ${pathname}`
 
-				this.triggerKeys.push({ triggerId, arguments: triggerArguments })
-				this.emit('trigger')
+				this.addTriggerEvent({ triggerId, arguments: triggerArguments })
 			}
 
 			res.end()

--- a/packages/input-manager/src/integrations/http/index.ts
+++ b/packages/input-manager/src/integrations/http/index.ts
@@ -31,8 +31,7 @@ export class HTTPDevice extends Device {
 				// Example: "https://localhost:8000/my/trigger/path?param0=hey#myHash"
 
 				const triggerArguments: TriggerEventArguments = {}
-
-				const url = new URL(req.url)
+				const url = new URL(req.url, 'http://localhost')
 				const searchParams: Record<string, any> = {}
 				for (const [key, value] of url.searchParams.entries()) {
 					searchParams[key] = value

--- a/packages/input-manager/src/integrations/osc/index.ts
+++ b/packages/input-manager/src/integrations/osc/index.ts
@@ -54,14 +54,18 @@ export class OSCDevice extends Device {
 			const triggerId = message.address
 
 			const messageArguments: TriggerEventArguments = {}
-			const args = Array.isArray(message.args) ? message.args : [message.args]
+			const args =
+				message.args instanceof Uint8Array
+					? [message.args]
+					: Array.isArray(message.args)
+					? message.args
+					: [message.args]
 
 			for (let i = 0; i < args.length; i++) {
 				messageArguments[`${i}`] = JSON.stringify(args[i])
 			}
 
-			this.triggerKeys.push({ triggerId, arguments: messageArguments })
-			this.emit('trigger')
+			this.addTriggerEvent({ triggerId, arguments: messageArguments })
 		})
 		this.#refreshInterval = setInterval(() => this.#refreshKnownSenders(), REFRESH_KNOWN_SENDERS)
 	}

--- a/packages/input-manager/src/integrations/osc/index.ts
+++ b/packages/input-manager/src/integrations/osc/index.ts
@@ -53,9 +53,8 @@ export class OSCDevice extends Device {
 
 			const triggerId = message.address
 
-			this.emit('trigger', {
-				triggerId,
-			})
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 		})
 		this.#refreshInterval = setInterval(() => this.#refreshKnownSenders(), REFRESH_KNOWN_SENDERS)
 	}

--- a/packages/input-manager/src/integrations/osc/index.ts
+++ b/packages/input-manager/src/integrations/osc/index.ts
@@ -1,6 +1,6 @@
 import * as osc from 'osc'
 import { Logger } from '../../logger'
-import { Device } from '../../devices/device'
+import { Device, TriggerEventArguments } from '../../devices/device'
 import { DeviceConfigManifest } from '../../lib'
 import { ConfigManifestEntryType } from '@sofie-automation/server-core-integration'
 import { SomeFeedback, Tally } from '../../feedback/feedback'
@@ -53,7 +53,14 @@ export class OSCDevice extends Device {
 
 			const triggerId = message.address
 
-			this.triggerKeys.push({ triggerId })
+			const messageArguments: TriggerEventArguments = {}
+			const args = Array.isArray(message.args) ? message.args : [message.args]
+
+			for (let i = 0; i < args.length; i++) {
+				messageArguments[`${i}`] = JSON.stringify(args[i])
+			}
+
+			this.triggerKeys.push({ triggerId, arguments: messageArguments })
 			this.emit('trigger')
 		})
 		this.#refreshInterval = setInterval(() => this.#refreshKnownSenders(), REFRESH_KNOWN_SENDERS)

--- a/packages/input-manager/src/integrations/skaarhoj/index.ts
+++ b/packages/input-manager/src/integrations/skaarhoj/index.ts
@@ -1,7 +1,7 @@
 import net from 'net'
 import { Logger } from '../../logger'
 import { Device } from '../../devices/device'
-import { DeviceConfigManifest, Symbols } from '../../lib'
+import { DEFAULT_ANALOG_RATE_LIMIT, DeviceConfigManifest, Symbols } from '../../lib'
 import { ClassNames, Label, SomeFeedback, Tally } from '../../feedback/feedback'
 import { ConfigManifestEntryType } from '@sofie-automation/server-core-integration'
 import { sleep } from '@sofie-automation/shared-lib/dist/lib/lib'
@@ -100,25 +100,23 @@ export class SkaarhojDevice extends Device {
 		if (state === 'Down') {
 			triggerId += ` ${Symbols.DOWN}`
 
-			this.triggerKeys.push({ triggerId })
-			this.emit('trigger')
+			this.addTriggerEvent({ triggerId })
 		} else if (state === 'Up') {
 			triggerId += ` ${Symbols.UP}`
 
-			this.triggerKeys.push({ triggerId })
-			this.emit('trigger')
+			this.addTriggerEvent({ triggerId })
 		} else {
 			const stateMatch = state.match(AnalogStateChange.StateChange)
 			if (stateMatch) {
-				this.triggerAnalogs.set(triggerId, {
-					[stateMatch[1]]: parseFloat(stateMatch[2]),
+				this.updateTriggerAnalog({ triggerId, rateLimit: DEFAULT_ANALOG_RATE_LIMIT }, () => {
+					return {
+						[stateMatch[1]]: parseFloat(stateMatch[2]),
+					}
 				})
-				this.emit('trigger')
 			} else {
 				// TODO: what should happen here?
 
-				this.triggerKeys.push({ triggerId })
-				this.emit('trigger')
+				this.addTriggerEvent({ triggerId })
 			}
 		}
 	}

--- a/packages/input-manager/src/integrations/skaarhoj/index.ts
+++ b/packages/input-manager/src/integrations/skaarhoj/index.ts
@@ -90,33 +90,37 @@ export class SkaarhojDevice extends Device {
 			this.logger.debug(`Uknown message from device: ${data}`)
 			return
 		}
-		let args: Record<string, number> | undefined = undefined
-		let trigger = match[1]
-		let replacesPrevious = false
+
+		let triggerId = match[1]
 		const mask = match[2]
 		const state = match[3]
 		if (mask) {
-			trigger += mask
+			triggerId += mask
 		}
 		if (state === 'Down') {
-			trigger += ` ${Symbols.DOWN}`
+			triggerId += ` ${Symbols.DOWN}`
+
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 		} else if (state === 'Up') {
-			trigger += ` ${Symbols.UP}`
+			triggerId += ` ${Symbols.UP}`
+
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 		} else {
 			const stateMatch = state.match(AnalogStateChange.StateChange)
 			if (stateMatch) {
-				args = {
+				this.triggerAnalogs.set(triggerId, {
 					[stateMatch[1]]: parseFloat(stateMatch[2]),
-				}
-				replacesPrevious = true
+				})
+				this.emit('trigger')
+			} else {
+				// TODO: what should happen here?
+
+				this.triggerKeys.push({ triggerId })
+				this.emit('trigger')
 			}
 		}
-
-		this.emit('trigger', {
-			triggerId: trigger,
-			arguments: args,
-			replacesPrevious,
-		})
 	}
 
 	async destroy(): Promise<void> {

--- a/packages/input-manager/src/integrations/streamdeck/__tests__/streamdeck.spec.ts
+++ b/packages/input-manager/src/integrations/streamdeck/__tests__/streamdeck.spec.ts
@@ -83,16 +83,19 @@ describe('Stream Deck', () => {
 		mockListeners['down'](1)
 
 		expect(triggerHandler).toHaveBeenCalledTimes(1)
-		expect(triggerHandler.mock.calls[0][0]).toMatchObject({
+		expect(device.getNextTrigger()).toMatchObject({
 			triggerId: `1 ${Symbols.DOWN}`,
 		})
+		expect(device.getNextTrigger()).toBeUndefined() // No more triggers to send
+		triggerHandler.mockClear()
 
 		mockListeners['up'](1)
 
-		expect(triggerHandler).toHaveBeenCalledTimes(2)
-		expect(triggerHandler.mock.calls[1][0]).toMatchObject({
+		expect(triggerHandler).toHaveBeenCalledTimes(1)
+		expect(device.getNextTrigger()).toMatchObject({
 			triggerId: `1 ${Symbols.UP}`,
 		})
+		expect(device.getNextTrigger()).toBeUndefined() // No more triggers to send
 	})
 	it('Changes the display on the button to match the Feedback', async () => {
 		const device = await connectToMockStreamDeck()

--- a/packages/input-manager/src/integrations/streamdeck/index.ts
+++ b/packages/input-manager/src/integrations/streamdeck/index.ts
@@ -76,102 +76,106 @@ export class StreamDeckDevice extends Device {
 		this.#streamDeck.addListener('down', (key) => {
 			const id = `${key}`
 			const triggerId = `${id} ${Symbols.DOWN}`
-			this.emit('trigger', {
-				triggerId,
-			})
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 
 			this.updateFeedback(id, true).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})
 		this.#streamDeck.addListener('up', (key) => {
 			const id = `${key}`
 			const triggerId = `${id} ${Symbols.UP}`
-			this.emit('trigger', {
-				triggerId,
-			})
+
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 
 			this.updateFeedback(id, false).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})
 		this.#streamDeck.addListener('encoderDown', (encoder) => {
 			const id = `Enc${encoder}`
 			const triggerId = `${id} ${Symbols.DOWN}`
-			this.emit('trigger', {
-				triggerId,
-			})
+
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 
 			this.updateFeedback(id, true).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})
 		this.#streamDeck.addListener('encoderUp', (encoder) => {
 			const id = `Enc${encoder}`
 			const triggerId = `${id} ${Symbols.UP}`
-			this.emit('trigger', {
-				triggerId,
-			})
+
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 
 			this.updateFeedback(id, false).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})
-		this.#streamDeck.addListener('rotateLeft', (encoder) => {
+		this.#streamDeck.addListener('rotateLeft', (encoder, deltaValue) => {
 			const id = `Enc${encoder}`
 			const triggerId = `${id} ${Symbols.JOG}`
-			this.emit('trigger', {
-				triggerId,
-				arguments: {
-					value: -1,
-				},
-			})
+
+			const event = (this.triggerAnalogs.get(triggerId) as { deltaValue: number }) || { deltaValue: 0 }
+			event.deltaValue -= deltaValue
+			this.triggerAnalogs.set(triggerId, event)
+			this.emit('trigger')
 
 			this.updateFeedback(id, false).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})
-		this.#streamDeck.addListener('rotateRight', (encoder) => {
+		this.#streamDeck.addListener('rotateRight', (encoder, deltaValue) => {
 			const id = `Enc${encoder}`
 			const triggerId = `${id} ${Symbols.JOG}`
-			this.emit('trigger', {
-				triggerId,
-				arguments: {
-					value: 1,
-				},
-			})
+
+			const event = (this.triggerAnalogs.get(triggerId) as { deltaValue: number }) || { deltaValue: 0 }
+			event.deltaValue += deltaValue
+			this.triggerAnalogs.set(triggerId, event)
+			this.emit('trigger')
 
 			this.updateFeedback(id, false).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})
 		this.#streamDeck.addListener('lcdShortPress', (encoder, position) => {
 			const id = `Enc${encoder}`
 			const triggerId = `${id} Tap`
-			this.emit('trigger', {
+
+			this.triggerKeys.push({
 				triggerId,
 				arguments: {
-					x: position.x,
-					y: position.y,
+					xPosition: position.x,
+					yPosition: position.y,
 				},
 			})
+			this.emit('trigger')
 
 			this.updateFeedback(id, false).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})
 		this.#streamDeck.addListener('lcdLongPress', (encoder, position) => {
 			const id = `Enc${encoder}`
 			const triggerId = `${id} Press`
-			this.emit('trigger', {
+
+			this.triggerKeys.push({
 				triggerId,
 				arguments: {
-					x: position.x,
-					y: position.y,
+					xPosition: position.x,
+					yPosition: position.y,
 				},
 			})
+			this.emit('trigger')
 
 			this.updateFeedback(id, false).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})
 		this.#streamDeck.addListener('lcdSwipe', (fromEncoder, toEncoder, from, to) => {
 			const id = `Enc${fromEncoder}`
 			const triggerId = `${id} Swipe`
-			this.emit('trigger', {
+
+			this.triggerKeys.push({
 				triggerId,
 				arguments: {
+					fromEncoder,
 					toEncoder,
-					fromX: from.x,
-					fromY: from.y,
-					toX: to.x,
-					toY: to.y,
+					fromXPosition: from.x,
+					fromYPosition: from.y,
+					toXPosition: to.x,
+					toYPosition: to.y,
 				},
 			})
+			this.emit('trigger')
 
 			this.updateFeedback(id, false).catch((err) => this.logger.error(`Stream Deck: Error updating feedback: ${err}`))
 		})

--- a/packages/input-manager/src/integrations/xkeys/index.ts
+++ b/packages/input-manager/src/integrations/xkeys/index.ts
@@ -113,62 +113,59 @@ export class XKeysDevice extends Device {
 
 		this.#device.on('down', (keyIndex) => {
 			const triggerId = `${keyIndex} ${Symbols.DOWN}`
-			this.emit('trigger', {
-				triggerId,
-			})
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 		})
 
 		this.#device.on('up', (keyIndex) => {
 			const triggerId = `${keyIndex} ${Symbols.UP}`
-			this.emit('trigger', {
-				triggerId,
-			})
+			this.triggerKeys.push({ triggerId })
+			this.emit('trigger')
 		})
 
-		this.#device.on('jog', (index, value) => {
+		this.#device.on('jog', (index, deltaValue) => {
 			const triggerId = `${index} ${Symbols.JOG}`
-			this.emit('trigger', {
-				triggerId,
-				arguments: {
-					value,
-				},
-			})
+			const event = (this.triggerAnalogs.get(triggerId) as { deltaValue: number }) || { deltaValue: 0 }
+			event.deltaValue += deltaValue
+			this.triggerAnalogs.set(triggerId, event)
+			this.emit('trigger')
 		})
 
-		this.#device.on('shuttle', (index, value) => {
+		this.#device.on('shuttle', (index, position) => {
 			const triggerId = `${index} ${Symbols.SHUTTLE}`
-			this.emit('trigger', {
-				triggerId,
-				arguments: {
-					value,
-				},
-				replacesPrevious: true,
-			})
+
+			this.triggerAnalogs.set(triggerId, { position })
+			this.emit('trigger')
 		})
 
-		this.#device.on('tbar', (index, value) => {
+		this.#device.on('tbar', (index, position) => {
 			const triggerId = `${index} ${Symbols.T_BAR}`
-			this.emit('trigger', {
-				triggerId,
-				arguments: {
-					value,
-				},
-				replacesPrevious: true,
-			})
+
+			this.triggerAnalogs.set(triggerId, { position })
+			this.emit('trigger')
 		})
 
-		this.#device.on('joystick', (index, value) => {
+		this.#device.on('joystick', (index, positions) => {
 			const triggerId = `${index} ${Symbols.MOVE}`
-			this.emit('trigger', {
-				triggerId,
-				arguments: {
-					x: value.x,
-					y: value.y,
-					z: value.z,
-					deltaZ: value.deltaZ,
-				},
-				replacesPrevious: true,
-			})
+
+			const event = (this.triggerAnalogs.get(triggerId) as {
+				yPosition: number
+				xPosition: number
+				zPosition: number
+				zDelta: number
+			}) || {
+				yPosition: 0,
+				xPosition: 0,
+				zPosition: 0,
+				zDelta: 0,
+			}
+			event.xPosition = positions.x
+			event.yPosition = positions.y
+			event.zPosition = positions.z
+			event.zDelta += positions.deltaZ
+
+			this.triggerAnalogs.set(triggerId, event)
+			this.emit('trigger')
 		})
 
 		this.#device.on('disconnected', () => {

--- a/packages/input-manager/src/lib.ts
+++ b/packages/input-manager/src/lib.ts
@@ -20,3 +20,11 @@ export function assertNever(_never: never): void {
 export type DeviceConfigManifest<ConfigObj extends object> = Array<
 	{ id: keyof ConfigObj } & Omit<TableEntryConfigManifestEntry, 'id'>
 >
+/** Removes and returns the first entry in a map */
+export function shiftMapFirstEntry<T>(theMap: Map<string, T>): { key: string; value: T } | undefined {
+	for (const [key, value] of theMap.entries()) {
+		theMap.delete(key)
+		return { key, value }
+	}
+	return undefined
+}

--- a/packages/input-manager/src/lib.ts
+++ b/packages/input-manager/src/lib.ts
@@ -20,11 +20,5 @@ export function assertNever(_never: never): void {
 export type DeviceConfigManifest<ConfigObj extends object> = Array<
 	{ id: keyof ConfigObj } & Omit<TableEntryConfigManifestEntry, 'id'>
 >
-/** Removes and returns the first entry in a map */
-export function shiftMapFirstEntry<T>(theMap: Map<string, T>): { key: string; value: T } | undefined {
-	for (const [key, value] of theMap.entries()) {
-		theMap.delete(key)
-		return { key, value }
-	}
-	return undefined
-}
+// The value, 50 ms, was chosen because it is approximate the time it takes for a human to click a key (key down + up).
+export const DEFAULT_ANALOG_RATE_LIMIT = 50


### PR DESCRIPTION
This PR does a few changes on how triggerEvents are generated and sent.

The changes are made to allow for rate-limiting the sending of analog values without loosing values inbetween.
For example when moving a jog-weel, the delta-values we receive from the device are `[1,1,1,1,1,-1,1,1]`, but we apply rate-limiting when senting the values, we should just send `[1,4,1]`.

This is achieved by letting the devices themselvs handle accumulation of previous values, and then queried (by `InputManagerHandler` for the latest updated trigger at the time of sending, using `device.getNextTrigger()`.

