### PR TITLE
fix: Correct path for generic node-hid bindings

### DIFF
--- a/packages/input-gateway/package.json
+++ b/packages/input-gateway/package.json
@@ -92,7 +92,7 @@
 	"pkg": {
 		"assets": [
 			"../../node_modules/@sofie-automation/server-core-integration/package.json",
-			"../input-manager/node_modules/node-hid/build/Release/HID.node",
+			"../../node_modules/node-hid/build/Release/HID.node",
 			"../../node_modules/xkeys/node_modules/node-hid/build/Release/HID.node",
 			"./package.json"
 		],


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Application fails to locate `node-hid` bindings when using a streamdeck device as they don't appear to have been included in the binary.


* **What is the new behavior (if this is a feature change)?**
Bindings are now included in the binary and work as expected.


* **Other information**:
