### PR TITLE
feat: drawable png background for streamdeck buttons SOFIE-3138

### DIFF
--- a/packages/input-gateway/package.json
+++ b/packages/input-gateway/package.json
@@ -73,8 +73,8 @@
 	],
 	"dependencies": {
 		"@sofie-automation/input-manager": "0.3.0-alpha.0",
-		"@sofie-automation/server-core-integration": "1.51.0-nightly-release51-20231117-131706-17bb2e3.0",
-		"@sofie-automation/shared-lib": "1.51.0-nightly-release51-20231117-131706-17bb2e3.0",
+		"@sofie-automation/server-core-integration": "1.51.0-nightly-release51-20240524-100952-fa306dc.0",
+		"@sofie-automation/shared-lib": "1.51.0-nightly-release51-20240524-100952-fa306dc.0",
 		"debug": "^4.3.4",
 		"eventemitter3": "^4.0.7",
 		"p-all": "^3.0.0",

--- a/packages/input-gateway/src/inputManagerHandler.ts
+++ b/packages/input-gateway/src/inputManagerHandler.ts
@@ -2,7 +2,7 @@ import _ from 'underscore'
 import * as Winston from 'winston'
 import { StatusCode } from '@sofie-automation/shared-lib/dist/lib/status'
 import { CoreHandler } from './coreHandler'
-import { DeviceSettings } from './interfaces'
+import { Complete, DeviceSettings } from './interfaces'
 import { PeripheralDeviceId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import {
 	DeviceActionArguments,
@@ -22,6 +22,7 @@ import {
 	SomeFeedback,
 	SomeDeviceConfig,
 	TriggerEvent,
+	Feedback,
 } from '@sofie-automation/input-manager'
 import { interpollateTranslation, translateMessage } from './lib/translatableMessage'
 import { ITranslatableMessage } from '@sofie-automation/shared-lib/dist/lib/translations'
@@ -31,7 +32,7 @@ import {
 	PeripheralDevicePubSub,
 	PeripheralDevicePubSubCollectionsNames,
 } from '@sofie-automation/server-core-integration'
-import { sleep } from '@sofie-automation/shared-lib/dist/lib/lib'
+import { literal, sleep } from '@sofie-automation/shared-lib/dist/lib/lib'
 import PQueue from 'p-queue'
 import { InputGatewaySettings } from './generated/options'
 
@@ -624,6 +625,7 @@ export class InputManagerHandler {
 		let contentLayerLongName: string | undefined
 		let contentLayerShortName: string | undefined
 		let tally: Tally = Tally.NONE
+		let stylePreset: string | undefined
 
 		if (actionId) {
 			const previewedAdlibs = this.#coreHandler.core
@@ -641,6 +643,7 @@ export class InputManagerHandler {
 				contentTypes = previewedAdlibs
 					.map((adlib) => adlib.sourceLayerType)
 					.filter((a) => a !== undefined) as SourceLayerType[]
+				stylePreset = previewedAdlibs[0].stylePreset
 			}
 		}
 
@@ -650,13 +653,14 @@ export class InputManagerHandler {
 
 		const actionName = mountedTrigger.actionType
 
-		return {
+		return literal<Complete<Feedback>>({
 			userLabel: userLabel ? { long: userLabel } : undefined,
 			action: mountedTrigger ? { long: actionName } : undefined,
 			contentClass: contentLayerLongName ? { long: contentLayerLongName, short: contentLayerShortName } : undefined,
 			content: contentLabel ? { long: contentLabel } : undefined,
 			classNames: InputManagerHandler.buildFeedbackClassNames(mountedTrigger, contentTypes),
 			tally,
-		}
+			stylePreset,
+		})
 	}
 }

--- a/packages/input-gateway/src/inputManagerHandler.ts
+++ b/packages/input-gateway/src/inputManagerHandler.ts
@@ -625,7 +625,7 @@ export class InputManagerHandler {
 		let contentLayerLongName: string | undefined
 		let contentLayerShortName: string | undefined
 		let tally: Tally = Tally.NONE
-		let stylePreset: string | undefined
+		let styleClassNames: string | undefined
 
 		if (actionId) {
 			const previewedAdlibs = this.#coreHandler.core
@@ -643,7 +643,8 @@ export class InputManagerHandler {
 				contentTypes = previewedAdlibs
 					.map((adlib) => adlib.sourceLayerType)
 					.filter((a) => a !== undefined) as SourceLayerType[]
-				stylePreset = previewedAdlibs[0].stylePreset
+				// @ts-expect-error lazy
+				styleClassNames = previewedAdlibs[0].styleClassNames
 			}
 		}
 
@@ -660,7 +661,7 @@ export class InputManagerHandler {
 			content: contentLabel ? { long: contentLabel } : undefined,
 			classNames: InputManagerHandler.buildFeedbackClassNames(mountedTrigger, contentTypes),
 			tally,
-			stylePreset,
+			styleClassNames,
 		})
 	}
 }

--- a/packages/input-gateway/src/inputManagerHandler.ts
+++ b/packages/input-gateway/src/inputManagerHandler.ts
@@ -643,7 +643,6 @@ export class InputManagerHandler {
 				contentTypes = previewedAdlibs
 					.map((adlib) => adlib.sourceLayerType)
 					.filter((a) => a !== undefined) as SourceLayerType[]
-				// @ts-expect-error lazy
 				styleClassNames = previewedAdlibs[0].styleClassNames
 			}
 		}

--- a/packages/input-gateway/src/interfaces.ts
+++ b/packages/input-gateway/src/interfaces.ts
@@ -1,3 +1,11 @@
 import { SomeDeviceConfig } from '@sofie-automation/input-manager'
 
 export type DeviceSettings = Record<string, SomeDeviceConfig>
+
+/**
+ * Make all optional properties be required and `| undefined`
+ * This is useful to ensure that no property is missed, when manually converting between types, but allowing fields to be undefined
+ */
+export type Complete<T> = {
+	[P in keyof Required<T>]: Pick<T, P> extends Required<Pick<T, P>> ? T[P] : T[P] | undefined
+}

--- a/packages/input-manager/package.json
+++ b/packages/input-manager/package.json
@@ -101,7 +101,6 @@
 		"xkeys": "^3.1.1"
 	},
 	"peerDependencies": {
-		"@sofie-automation/server-core-integration": "*",
 		"@sofie-automation/shared-lib": "*"
 	},
 	"publishConfig": {

--- a/packages/input-manager/src/feedback/bitmap/index.ts
+++ b/packages/input-manager/src/feedback/bitmap/index.ts
@@ -1,5 +1,5 @@
 import { Canvas, FontLibrary } from 'skia-canvas'
-import { SomeFeedback } from '../feedback'
+import { SomeBitmapFeedback } from '../feedback'
 import { rendererFactory } from './typeRenderers/factory'
 import path from 'path'
 import fs from 'fs/promises'
@@ -7,7 +7,7 @@ import { constants as fsConstants } from 'fs'
 import process from 'process'
 
 async function makeBitmapFromFeedback(
-	feedback: SomeFeedback,
+	feedback: SomeBitmapFeedback,
 	width: number,
 	height: number,
 	isPressed: boolean
@@ -38,7 +38,7 @@ async function makeBitmapFromFeedback(
 }
 
 export async function getBitmap(
-	feedback: SomeFeedback,
+	feedback: SomeBitmapFeedback,
 	width: number,
 	height: number,
 	isPressed?: boolean

--- a/packages/input-manager/src/feedback/bitmap/typeRenderers/action.ts
+++ b/packages/input-manager/src/feedback/bitmap/typeRenderers/action.ts
@@ -1,17 +1,23 @@
-import { Feedback } from '../../feedback'
+import { BitmapFeedback } from '../../feedback'
 import { BaseRenderer } from './base'
 
 export class ActionRenderer extends BaseRenderer {
-	render(feedback: Feedback): void {
-		const text = this.text
-		const label = feedback?.userLabel?.long ?? feedback?.action?.long
-		text.p({
-			children: label ?? 'unknown',
-			align: 'center',
-			fontSize: this.percentToPixels(1.5),
-			spring: true,
-			background: 'linear-gradient(to bottom, #333, #000)',
-			lineClamp: 4,
-		})
+	render(feedback: BitmapFeedback): void {
+		if (feedback.backgroundImage) {
+			this.drawBackgroundImage(feedback.backgroundImage)
+		}
+
+		if (!feedback.hideText) {
+			const text = this.text
+			const label = feedback?.userLabel?.long ?? feedback?.action?.long
+			text.p({
+				children: label ?? 'unknown',
+				align: 'center',
+				fontSize: this.percentToPixels(1.5),
+				spring: true,
+				background: !feedback.backgroundImage ? 'linear-gradient(to bottom, #333, #000)' : undefined,
+				lineClamp: 4,
+			})
+		}
 	}
 }

--- a/packages/input-manager/src/feedback/bitmap/typeRenderers/adlib/base.ts
+++ b/packages/input-manager/src/feedback/bitmap/typeRenderers/adlib/base.ts
@@ -1,4 +1,4 @@
-import { ClassNames, Feedback } from '../../../feedback'
+import { ClassNames, BitmapFeedback } from '../../../feedback'
 import { BaseRenderer } from '../base'
 
 /**
@@ -72,21 +72,28 @@ export class BaseAdLibRenderer extends BaseRenderer {
 		return 1
 	}
 
-	render(feedback: Feedback): void {
+	render(feedback: BitmapFeedback): void {
 		const text = this.text
 		// text.p({ children: feedback?.action?.long ?? 'unknown', align: 'center', lineClamp: 1 })
 		// text.hr({})
 		if (!feedback?.content) return
-		const label = feedback?.userLabel?.long ?? feedback?.content?.long ?? ''
-		text.p({
-			children: label,
-			align: 'center',
-			spring: true,
-			fontSize: this.percentToPixels(this.getFontSize(label)),
-			lineHeight: this.percentToPixels(this.getFontSize(label)),
-			background: this.getAdLibColor(feedback.classNames),
-			textShadowOffset: 1,
-			lineClamp: 4,
-		})
+
+		if (feedback.backgroundImage) {
+			this.drawBackgroundImage(feedback.backgroundImage)
+		}
+
+		if (!feedback.hideText) {
+			const label = feedback?.userLabel?.long ?? feedback?.content?.long ?? ''
+			text.p({
+				children: label,
+				align: 'center',
+				spring: true,
+				fontSize: this.percentToPixels(this.getFontSize(label)),
+				lineHeight: this.percentToPixels(this.getFontSize(label)),
+				background: !feedback.backgroundImage ? this.getAdLibColor(feedback.classNames) : undefined,
+				textShadowOffset: 1,
+				lineClamp: 4,
+			})
+		}
 	}
 }

--- a/packages/input-manager/src/feedback/bitmap/typeRenderers/base.ts
+++ b/packages/input-manager/src/feedback/bitmap/typeRenderers/base.ts
@@ -1,4 +1,4 @@
-import { CanvasRenderingContext2D } from 'skia-canvas'
+import { CanvasRenderingContext2D, Image } from 'skia-canvas'
 import { Feedback } from '../../feedback'
 import { TextContext } from '../lib/TextContext'
 
@@ -20,4 +20,10 @@ export abstract class BaseRenderer {
 	}
 
 	abstract render(feedback: Feedback): void
+
+	protected drawBackgroundImage(backgroundImage: string): void {
+		const myImage = new Image()
+		myImage.src = backgroundImage
+		this.ctx.drawImage(myImage, 0, 0, this.width, this.height)
+	}
 }

--- a/packages/input-manager/src/feedback/bitmap/typeRenderers/factory.ts
+++ b/packages/input-manager/src/feedback/bitmap/typeRenderers/factory.ts
@@ -1,11 +1,11 @@
 import { CanvasRenderingContext2D } from 'skia-canvas'
-import { ClassNames, Feedback } from '../../feedback'
+import { BitmapFeedback, ClassNames } from '../../feedback'
 import { ActionRenderer } from './action'
 import { BaseAdLibRenderer } from './adlib/base'
 import { BaseRenderer } from './base'
 
 export function rendererFactory(
-	feedback: Feedback,
+	feedback: BitmapFeedback,
 	ctx: CanvasRenderingContext2D,
 	width: number,
 	height: number,

--- a/packages/input-manager/src/feedback/feedback.ts
+++ b/packages/input-manager/src/feedback/feedback.ts
@@ -58,16 +58,12 @@ export interface Feedback {
 	content?: Label
 	/** The label for the type of content attached to this Action */
 	contentClass?: Label
-	// /** The duration of the content attached to this Action */
-	// duration?: string
 	/** The tally state bitmap */
 	tally?: Tally
 	/** Various classes attached to this Action - including the ones defined in `ClassNames` */
 	classNames?: string[]
-	// /** A PNG image of the content attached to this Action */
-	// thumbnail?: Blob
-	/** The id of the style preset to use when drawing the button */
-	stylePreset?: string
+	/** Space separated list of class names to use when drawing the button */
+	styleClassNames?: string
 }
 
 export type SomeFeedback = Feedback | null

--- a/packages/input-manager/src/feedback/feedback.ts
+++ b/packages/input-manager/src/feedback/feedback.ts
@@ -1,5 +1,3 @@
-import { Blob } from 'buffer'
-
 export interface Label {
 	/** Optional, short representation of the label, up to 10 chars */
 	short?: string
@@ -60,14 +58,22 @@ export interface Feedback {
 	content?: Label
 	/** The label for the type of content attached to this Action */
 	contentClass?: Label
-	/** The duration of the content attached to this Action */
-	duration?: string
+	// /** The duration of the content attached to this Action */
+	// duration?: string
 	/** The tally state bitmap */
 	tally?: Tally
 	/** Various classes attached to this Action - including the ones defined in `ClassNames` */
 	classNames?: string[]
-	/** A PNG image of the content attached to this Action */
-	thumbnail?: Blob
+	// /** A PNG image of the content attached to this Action */
+	// thumbnail?: Blob
+	/** The id of the style preset to use when drawing the button */
+	stylePreset?: string
 }
 
 export type SomeFeedback = Feedback | null
+
+export interface BitmapFeedback extends Feedback {
+	backgroundImage?: string
+	hideText?: boolean
+}
+export type SomeBitmapFeedback = BitmapFeedback | null

--- a/packages/input-manager/src/generated/streamdeck.ts
+++ b/packages/input-manager/src/generated/streamdeck.ts
@@ -10,4 +10,16 @@ export interface StreamDeckDeviceOptions {
 	serialNumber?: string
 	index?: number
 	brightness?: number
+	stylePresets?: {
+		[k: string]: StreamdeckStylePreset
+	}
+}
+/**
+ * This interface was referenced by `undefined`'s JSON-Schema definition
+ * via the `patternProperty` "".
+ */
+export interface StreamdeckStylePreset {
+	id: string
+	backgroundImage: string
+	drawText: boolean
 }

--- a/packages/input-manager/src/integrations/streamdeck/$schemas/options.json
+++ b/packages/input-manager/src/integrations/streamdeck/$schemas/options.json
@@ -1,32 +1,69 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "urn:local:nrk.no/sofie-input-gateway/integration-settings/stream-deck",
-    "title": "Stream Deck Device Options",
-    "type": "object",
-    "properties": {
-        "path": {
-            "type": "string",
-            "ui:title": "Device Path",
-            "ui:description": "The device path or part of it, where the device is attached in the system device tree"
-        },
-        "serialNumber": {
-            "type": "string",
-            "ui:title": "Serial Number",
-            "ui:description": "The serial number of the device"
-        },
-        "index": {
-            "type": "integer",
-            "ui:title": "Device Index",
-            "ui:description": "The index on the list of attached Stream Deck devices"
-        },
-        "brightness": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 100,
-            "ui:title": "Display brightness",
-            "ui:description": "Set the intensity of the backlight on the Stream Deck device screen"
-        }
-    },
-    "required": [],
-    "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "urn:local:nrk.no/sofie-input-gateway/integration-settings/stream-deck",
+	"title": "Stream Deck Device Options",
+	"type": "object",
+	"properties": {
+		"path": {
+			"type": "string",
+			"ui:title": "Device Path",
+			"ui:description": "The device path or part of it, where the device is attached in the system device tree"
+		},
+		"serialNumber": {
+			"type": "string",
+			"ui:title": "Serial Number",
+			"ui:description": "The serial number of the device"
+		},
+		"index": {
+			"type": "integer",
+			"ui:title": "Device Index",
+			"ui:description": "The index on the list of attached Stream Deck devices"
+		},
+		"brightness": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 100,
+			"ui:title": "Display brightness",
+			"ui:description": "Set the intensity of the backlight on the Stream Deck device screen"
+		},
+		"stylePresets": {
+			"type": "object",
+			"ui:title": "Style Presets",
+			"ui:description": "Styling definitions to use when drawing the buttons",
+			"patternProperties": {
+				"": {
+					"type": "object",
+					"title": "StreamdeckStylePreset",
+					"properties": {
+						"id": {
+							"type": "string",
+							"ui:title": "Preset Style Id",
+							"ui:description": "",
+							"ui:summaryTitle": "Id",
+							"default": ""
+						},
+						"backgroundImage": {
+							"type": "string",
+							"ui:title": "Background Image",
+							"ui:description": "",
+							"ui:summaryTitle": "Image",
+							"ui:displayType": "base64-image",
+							"default": ""
+						},
+						"drawText": {
+							"type": "boolean",
+							"ui:title": "Draw Text",
+							"ui:description": "Whether to draw text on this button",
+							"default": false
+						}
+					},
+					"required": ["id", "backgroundImage", "drawText"],
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"required": [],
+	"additionalProperties": false
 }

--- a/packages/input-manager/src/integrations/streamdeck/$schemas/options.json
+++ b/packages/input-manager/src/integrations/streamdeck/$schemas/options.json
@@ -30,6 +30,8 @@
 			"type": "object",
 			"ui:title": "Style Presets",
 			"ui:description": "Styling definitions to use when drawing the buttons",
+			"ui:import-export": true,
+
 			"patternProperties": {
 				"": {
 					"type": "object",

--- a/packages/input-manager/src/integrations/streamdeck/index.ts
+++ b/packages/input-manager/src/integrations/streamdeck/index.ts
@@ -250,19 +250,27 @@ export class StreamDeckDevice extends Device {
 	}
 
 	private convertFeedbackToBitmapFeedback(feedback: Feedback): BitmapFeedback | Feedback {
-		const stylePresetId = feedback.stylePreset
-		if (!stylePresetId || !this.config.stylePresets) return feedback
+		const styleClassNames = feedback.styleClassNames
+		if (!styleClassNames || !this.config.stylePresets) return feedback
 
-		const stylePreset = Object.values<StreamdeckStylePreset>(this.config.stylePresets).find(
-			(preset) => preset.id === stylePresetId
-		)
-		if (!stylePreset) return feedback
+		console.log('test', styleClassNames)
 
-		return {
-			...feedback,
-			backgroundImage: stylePreset.backgroundImage,
-			hideText: !stylePreset.drawText,
+		// Find the first match
+		for (const name of styleClassNames.split(' ')) {
+			const stylePreset = Object.values<StreamdeckStylePreset>(this.config.stylePresets).find(
+				(preset) => preset.id === name
+			)
+
+			if (stylePreset) {
+				return {
+					...feedback,
+					backgroundImage: stylePreset.backgroundImage,
+					hideText: !stylePreset.drawText,
+				}
+			}
 		}
+
+		return feedback
 	}
 
 	private quietUpdateFeedbackWithDownState = (trigger: string): void => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,7 +1755,6 @@ __metadata:
     skia-canvas: "npm:^1.0.1"
     xkeys: "npm:^3.1.1"
   peerDependencies:
-    "@sofie-automation/server-core-integration": "*"
     "@sofie-automation/shared-lib": "*"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,10 +1036,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mos-connection/model@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "@mos-connection/model@npm:3.0.4"
-  checksum: 10/3f0e7a845c0aa55c655f4a77dac4297ef76a2b138997c4d89d668adefd174804a4ebb5e35c4df8485c68cf50d95fac651e68ea1b1f89bfe2bde9000e7e0b1480
+"@mos-connection/model@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@mos-connection/model@npm:4.1.0"
+  checksum: 10/c57eeac9f7fc0b783cafe0e64f2d46ec017cb515b4cd6f3b2fb8126252672f5354bb27f6c23abe9a56312f20497619d5e678b46ae9e204ef9d30f33490ea536c
   languageName: node
   linkType: hard
 
@@ -1759,30 +1759,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sofie-automation/server-core-integration@npm:1.51.0-nightly-release51-20231117-131706-17bb2e3.0":
-  version: 1.51.0-nightly-release51-20231117-131706-17bb2e3.0
-  resolution: "@sofie-automation/server-core-integration@npm:1.51.0-nightly-release51-20231117-131706-17bb2e3.0"
+"@sofie-automation/server-core-integration@npm:1.51.0-nightly-release51-20240524-100952-fa306dc.0":
+  version: 1.51.0-nightly-release51-20240524-100952-fa306dc.0
+  resolution: "@sofie-automation/server-core-integration@npm:1.51.0-nightly-release51-20240524-100952-fa306dc.0"
   dependencies:
-    "@sofie-automation/shared-lib": "npm:1.51.0-nightly-release51-20231117-131706-17bb2e3.0"
+    "@sofie-automation/shared-lib": "npm:1.51.0-nightly-release51-20240524-100952-fa306dc.0"
     ejson: "npm:^2.2.3"
     eventemitter3: "npm:^4.0.7"
     faye-websocket: "npm:^0.11.4"
     got: "npm:^11.8.6"
     tslib: "npm:^2.6.2"
     underscore: "npm:^1.13.6"
-  checksum: 10/63d16749f76d433234e5ef0be51d7f24e5c3e8192646e3df7a80d7617e0869ea3aac74c7eede0035117cd7dd6f93455ec7cd21a6682fc0c1a55f77bf705f1ace
+  checksum: 10/f8c496a5aa4b6680018923ae6377067db11da590a3a0182f4bb30a7e1af93cf5ba75623f239968634a34c37ab62dc171c09a5a8fdfb819712ef56a36ac68ce63
   languageName: node
   linkType: hard
 
-"@sofie-automation/shared-lib@npm:1.51.0-nightly-release51-20231117-131706-17bb2e3.0":
-  version: 1.51.0-nightly-release51-20231117-131706-17bb2e3.0
-  resolution: "@sofie-automation/shared-lib@npm:1.51.0-nightly-release51-20231117-131706-17bb2e3.0"
+"@sofie-automation/shared-lib@npm:1.51.0-nightly-release51-20240524-100952-fa306dc.0":
+  version: 1.51.0-nightly-release51-20240524-100952-fa306dc.0
+  resolution: "@sofie-automation/shared-lib@npm:1.51.0-nightly-release51-20240524-100952-fa306dc.0"
   dependencies:
-    "@mos-connection/model": "npm:^3.0.4"
-    timeline-state-resolver-types: "npm:9.1.0-nightly-release51-20231116-111000-10d150936.0"
+    "@mos-connection/model": "npm:^4.1.0"
+    timeline-state-resolver-types: "npm:9.1.0-nightly-release51-20240228-132329-b7ceb6950.0"
     tslib: "npm:^2.6.2"
     type-fest: "npm:^3.13.1"
-  checksum: 10/03f3e976235c8960e53cf15e917b1da5988f0e5b5da78e89fe728d5ddd1a1c471d8b15094724bf85445682f429f1184569013b326ebabe03a20ed81901627aad
+  checksum: 10/183f278c8c953e06a9c1da755f0d192a7ad131dca7bf642c4e42948ee668ad26ebb640c878fe96cfe4def9549a44560561237f4964f5029879baab05e77ef3af
   languageName: node
   linkType: hard
 
@@ -5693,8 +5693,8 @@ __metadata:
   resolution: "input-gateway@workspace:packages/input-gateway"
   dependencies:
     "@sofie-automation/input-manager": "npm:0.3.0-alpha.0"
-    "@sofie-automation/server-core-integration": "npm:1.51.0-nightly-release51-20231117-131706-17bb2e3.0"
-    "@sofie-automation/shared-lib": "npm:1.51.0-nightly-release51-20231117-131706-17bb2e3.0"
+    "@sofie-automation/server-core-integration": "npm:1.51.0-nightly-release51-20240524-100952-fa306dc.0"
+    "@sofie-automation/shared-lib": "npm:1.51.0-nightly-release51-20240524-100952-fa306dc.0"
     debug: "npm:^4.3.4"
     eventemitter3: "npm:^4.0.7"
     p-all: "npm:^3.0.0"
@@ -10575,12 +10575,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-types@npm:9.1.0-nightly-release51-20231116-111000-10d150936.0":
-  version: 9.1.0-nightly-release51-20231116-111000-10d150936.0
-  resolution: "timeline-state-resolver-types@npm:9.1.0-nightly-release51-20231116-111000-10d150936.0"
+"timeline-state-resolver-types@npm:9.1.0-nightly-release51-20240228-132329-b7ceb6950.0":
+  version: 9.1.0-nightly-release51-20240228-132329-b7ceb6950.0
+  resolution: "timeline-state-resolver-types@npm:9.1.0-nightly-release51-20240228-132329-b7ceb6950.0"
   dependencies:
-    tslib: "npm:^2.5.1"
-  checksum: 10/f9d605c9083530daad79985aa63e352d2f665928b396b066b92ccc1807ecd52c1ce56d00bd7f5007cc994a9f84ef3d6b4e71be14b45b923e3608ec441b2fdb60
+    tslib: "npm:^2.6.2"
+  checksum: 10/9299b3c94cb271bbd4ca3cc21389953a7bca4d13818babab8a46af814499e7917fb07227ff6b3fd509761ed40df8f925833d4c825b56fc1911a207fbaa2bf85d
   languageName: node
   linkType: hard
 
@@ -10789,7 +10789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.1, tslib@npm:^2.6.2":
+"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10/bd26c22d36736513980091a1e356378e8b662ded04204453d353a7f34a4c21ed0afc59b5f90719d4ba756e581a162ecbf93118dc9c6be5acf70aa309188166ca


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a:  Feature 


## New Behavior
Adds support for more advanced drawing controls.
For now this is limited to just the streamdeck, and drawing images. 

The images are expected to be in the format of base64 encoded data urls.

The drawing is controlled by a new `stylePreset` property on the action triggers. It is up to each device integration to define the meaning of these `stylePresets`, this is because each device can have differing abilities on what it is able to draw.

This relies upon the following PRs:
- https://github.com/nrkno/sofie-core/pull/1191
- https://github.com/nrkno/sofie-core/pull/1192


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
