### PR TITLE
feat: Use Kubernetes API for restarting when running in a k8s environment

### DIFF
--- a/packages/input-gateway/package.json
+++ b/packages/input-gateway/package.json
@@ -74,7 +74,7 @@
 	"dependencies": {
 		"@esm2cjs/p-queue": "7.3.0",
 		"@sofie-automation/input-manager": "0.4.0",
-		"@sofie-automation/server-core-integration": "1.53.0-nightly-release53-20251210-154915-f7afd72.0",
+		"@sofie-automation/server-core-integration": "1.52.18-nightly-feat-kubernetes-restart-20260729-115546-3710689.0",
 		"@sofie-automation/shared-lib": "1.53.0-nightly-release53-20251210-154915-f7afd72.0",
 		"debug": "^4.3.4",
 		"eventemitter3": "5.0.1",

--- a/packages/input-gateway/src/coreHandler.ts
+++ b/packages/input-gateway/src/coreHandler.ts
@@ -12,6 +12,7 @@ import {
 	stringifyError,
 	PeripheralDeviceCommand,
 	ICoreHandler,
+	KubernetesRestarter,
 } from '@sofie-automation/server-core-integration'
 import { PeripheralDeviceCommandId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
 import _ from 'underscore'
@@ -54,6 +55,8 @@ export class CoreHandler implements ICoreHandler {
 
 	public connectedToCore = false
 
+	private _k8sRestarter?: KubernetesRestarter
+
 	private _processState: {
 		[key: string]: {
 			comments: string[]
@@ -65,6 +68,9 @@ export class CoreHandler implements ICoreHandler {
 		this.logger = logger
 		this._deviceOptions = deviceOptions
 		this._processState = {}
+		if (KubernetesRestarter.canUseK8sRestarter()) {
+			this._k8sRestarter = new KubernetesRestarter(this.logger, 'sofie-input-gateway')
+		}
 	}
 
 	async init(config: CoreConfig, process: Process): Promise<void> {
@@ -284,16 +290,18 @@ export class CoreHandler implements ICoreHandler {
 			}
 		})
 	}
-	killProcess(actually: number): boolean {
-		if (actually === 1) {
-			this.logger.info('KillProcess command received, shutting down in 1000ms!')
+	async killProcess(): Promise<void> {
+		this.logger.info('KillProcess command received for playout-gateway')
+		if (this._k8sRestarter) {
+			this.logger.info('Running on kubernetes was true, restarting deployment')
+			await this._k8sRestarter.restartKube()
+		} else {
+			this.logger.info('killing process in 1000ms!')
 			setTimeout(() => {
 				// eslint-disable-next-line no-process-exit
 				process.exit(0)
 			}, 1000)
-			return true
 		}
-		return false
 	}
 	/* devicesMakeReady (okToDestroyStuff?: boolean): Promise<any> {
 		// TODO: perhaps do something here?

--- a/packages/input-gateway/src/coreHandler.ts
+++ b/packages/input-gateway/src/coreHandler.ts
@@ -291,7 +291,7 @@ export class CoreHandler implements ICoreHandler {
 		})
 	}
 	async killProcess(): Promise<void> {
-		this.logger.info('KillProcess command received for playout-gateway')
+		this.logger.info('KillProcess command received for input-gateway')
 		if (this._k8sRestarter) {
 			this.logger.info('Running on kubernetes was true, restarting deployment')
 			await this._k8sRestarter.restartKube()

--- a/packages/input-gateway/src/coreHandler.ts
+++ b/packages/input-gateway/src/coreHandler.ts
@@ -290,17 +290,18 @@ export class CoreHandler implements ICoreHandler {
 			}
 		})
 	}
-	async killProcess(): Promise<void> {
+	async killProcess(): Promise<boolean> {
 		this.logger.info('KillProcess command received for input-gateway')
 		if (this._k8sRestarter) {
 			this.logger.info('Running on kubernetes was true, restarting deployment')
-			await this._k8sRestarter.restartKube()
+			return await this._k8sRestarter.restartKube()
 		} else {
 			this.logger.info('killing process in 1000ms!')
 			setTimeout(() => {
 				// eslint-disable-next-line no-process-exit
 				process.exit(0)
 			}, 1000)
+			return true;
 		}
 	}
 	/* devicesMakeReady (okToDestroyStuff?: boolean): Promise<any> {


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Feature

## Current Behavior

Restarting the gateway triggers the killProcess method that terminates the currently running node process. If the application is deployed in Kubernetes, and the user tries to restart the gateway before the last restart has finished, Kubernetes thinks that the app is in crashloopbackoff and starts stalling subsequent restart attempts.

## New Behavior

When the restart is triggered, it checks if the env variable RUNS_ON_K8S is true, if it is then it uses a new method defined in the server-core-integration library that restarts the gateway by using the Kubernetes API.

## Testing Instructions

Deploy the application to Kubernetes 
Add the env variables RUNS_ON_K8S set to true and DEPLOYMENT_NAME to sofie-input-gateway in the deployment manifest. 
You will also need to have a service account in the namespace it is deployed to that has permissions to do a patch for deployments.
Attempt to restart the gateway.

## Other Information

I have not gotten to test this functionality for the input-gateway yet. I have tested it for playout-gateway and mos-gateway and it worked there.
I am using a version of the server-core-integration npm package that is from the @nrk/sofie-server-core-integration and not @sofie-automation/server-core-integration which will probably need to be fixed before merging changes to Sofie-automation/input-gateway repo.

## Status

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
